### PR TITLE
Bug #64144: Process pending buildreqs during the API call that generates them.

### DIFF
--- a/memcache_pool.c
+++ b/memcache_pool.c
@@ -1673,7 +1673,7 @@ void mmc_pool_run(mmc_pool_t *pool TSRMLS_DC)  /*
 	mmc_t *mmc;
 	while (pool->reading->len || pool->sending->len || pool->pending.len) {
 		/**
-		 * Each Server on the pool's pending queue have a buildreq in process,
+		 * Each server on the pool's pending queue has a buildreq in process,
 		 * created while processing a request previously on the reading or
 		 * sending queue (e.g. due to a failover). Finalize the buildreq and
 		 * add it to the sending and reading queue via mmc_pool_schedule(), so


### PR DESCRIPTION
See the comments at https://bugs.php.net/bug.php?id=64144 for an explanation of why this is necessary. Failover get requests are added to a pool's pending queue, but then are not run until the next memcache API call, by which time the location into which the return value is written is no longer valid. I'm not sure how/if failover get requests have ever worked.

However, I am far from 100% certain that this patch is right, since I do not have a complete understanding of the code.
