### PR TITLE
Fix 8.0 compatibility

### DIFF
--- a/memcache.c
+++ b/memcache.c
@@ -1093,7 +1093,7 @@ void mmc_server_deactivate(mmc_t *mmc TSRMLS_DC) /* 	disconnect and marks the se
 		}
 		ZVAL_LONG(errnum, mmc->errnum);
 
-		call_user_function_ex(EG(function_table), NULL, mmc->failure_callback, &retval, 5, params, 0, NULL TSRMLS_CC);
+		call_user_function(EG(function_table), NULL, mmc->failure_callback, &retval, 5, params);
 
 		zval_ptr_dtor(&host);
 		zval_ptr_dtor(&tcp_port); zval_ptr_dtor(&udp_port);

--- a/memcache.c
+++ b/memcache.c
@@ -37,7 +37,7 @@
 #include "ext/standard/info.h"
 #include "ext/standard/php_string.h"
 #include "ext/standard/php_var.h"
-#include "ext/standard/php_smart_str.h"
+#include "Zend/zend_smart_str.h"
 #include "php_network.h"
 #include "php_memcache.h"
 #include "memcache_queue.h"

--- a/php_memcache.h
+++ b/php_memcache.h
@@ -35,7 +35,7 @@ extern zend_module_entry memcache_module_entry;
 #include "TSRM.h"
 #endif
 
-#include "ext/standard/php_smart_str_public.h"
+#include "Zend/zend_smart_str_public.h"
 
 PHP_MINIT_FUNCTION(memcache);
 PHP_MSHUTDOWN_FUNCTION(memcache);


### PR DESCRIPTION
- replace `call_user_function_ex()` with `call_user_function()` ref https://github.com/php/php-src/commit/302933daea77663f5759b10accd1d0231393b24c